### PR TITLE
feat: add maintenance mode middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import { get } from "@vercel/edge-config";
+import { NextRequest, NextResponse } from "next/server";
+
+// ============================================================================
+
+export const config = { matcher: "/" };
+
+// ============================================================================
+
+export async function middleware(req: NextRequest) {
+  try {
+    if (await get("isUnderMaintenance")) {
+      req.nextUrl.pathname = "/_maintenance";
+
+      return NextResponse.rewrite(req.nextUrl);
+    }
+  } catch (error) {
+    // console.error(error);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@sentry/nextjs": "7.47.0",
     "@vercel/analytics": "0.1.11",
+    "@vercel/edge-config": "0.1.7",
     "next": "13.3.0",
     "next-sitemap": "4.0.7",
     "react": "18.2.0",

--- a/pages/_maintenance.tsx
+++ b/pages/_maintenance.tsx
@@ -1,0 +1,11 @@
+const Maintenance = () => {
+  return (
+    <div>
+      <h1>Coming soon™</h1>
+    </div>
+  );
+};
+
+// ============================================================================
+
+export default Maintenance;

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,6 +859,11 @@
   resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-0.1.11.tgz#727a0ac655a4a89104cdea3e6925476470299428"
   integrity sha512-mj5CPR02y0BRs1tN3oZcBNAX9a8NxsIUl9vElDPcqxnMfP0RbRc9fI9Ud7+QDg/1Izvt5uMumsr+6YsmVHcyuw==
 
+"@vercel/edge-config@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@vercel/edge-config/-/edge-config-0.1.7.tgz#1d65e4353dd969caf26190fa4525cc20cf1d7791"
+  integrity sha512-mXKotO6Tss6Ke6mhHC21m6EggV3hO9RrxUgKEUbOb/KY+IJKl35wKKCYuFCDLXtwk9OfpJkQbXeu/MiIjseAOw==
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
Add a new middleware to handle maintenance mode. The middleware checks if the `isUnderMaintenance` flag is set in the `@vercel/edge-config` package. If the flag is set, the middleware rewrites the request URL to the `_maintenance` page.

Also, add the `@vercel/edge-config` package as a dependency in the `package.json` file.

Finally, add a `_maintenance` page to display a "Coming soon™" message.