### PR TITLE
Release

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -31,7 +31,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? "en", ["common"])),
   },
-  revalidate: 60,
+  // revalidate: 60,
 });
 
 // ============================================================================

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,7 +39,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? "en", ["common"])),
   },
-  revalidate: 60,
+  // revalidate: 60,
 });
 
 // ============================================================================


### PR DESCRIPTION
chore(pages): comment out revalidate property in getStaticProps

The revalidate property in getStaticProps has been commented out in both the 404.tsx and index.tsx files.