### PR TITLE
refactor(turbo.json): simplify build and postbuild outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,12 +2,10 @@
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "build": {
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**",
-        "!public/*.xml",
-        "!public/robots.txt"
-      ]
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "postbuild": {
+      "outputs": ["!public/*.xml", "!public/robots.txt"]
     },
     "lint": {}
   }


### PR DESCRIPTION
- Remove public/*.xml and public/robots.txt from build outputs
- Combine build and postbuild outputs into one object
- Remove empty lint object